### PR TITLE
[features] Custom error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ extension User: Validatable {
         validations.add(\.website, ["website"], .nil || .url)
 
         // 'twitter' should be nil or began by '@'.
-        validations.add(\.twitter, at: ["twitter"]) { twitter in
+        validations.add(\.twitter, at: ["twitter"], validator: { twitter in
         	guard let twitter = twitter else { return }
             guard twitter.first != "@" else { return }
             throw BasicValidationError("isn't a valid Twitter username")
-        }
+        })
+        
         return validations
     }
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,32 @@ Or you can validate a single field, specified at `keyPath`:
 try valid.validate(at: \User.mail)
 ```
 
-You also can take a look to a demo application in the `ValidationsKitDemo` directory, using Cocoapods.
+Finally, you can now define your own message to be thrown in a case of validations failure, which can be handy to pass some localised string or just display some custom message to end user:
+
+```swift
+struct User: Validatable {
+    let age: Int
+    
+    static func validations() throws -> Validations<User> {
+        var validations = Validations(User.self)
+        
+        validations.add(\.age, at: ["age"], .range(..< 12) { age in
+            "You have to be at most 12 for doing this, \(age) is too old for that stuff..."
+        }
+        
+        return validations
+    }
+
+}
+
+do {
+    try User(age: 42)
+} catch {
+    print("\(error)") // "You have to be at most 12 for doing this, 42 is too old for that stuff..."
+}
+```
+
+You can also take a look to a demo application in the `ValidationsKitDemo` directory, using Cocoapods.
 
 ## Installation
 ### Cocoapods
@@ -106,7 +131,7 @@ $ swift package update
 
 ## Difference from Vapor package
 
-The main difference from Vapor package is that it doesn't include the `Reflectable` system, that allow you to make your model conform both to `Decodable` and `Reflectable` to avoid typing the key path to show in case of errors, which can lead to errors is variable are rename in the future.
+The main difference from Vapor package is that it doesn't include the `Reflectable` system, that allow you to make your model conform both to `Decodable` and `Reflectable` to avoid typing the key path to show in case of errors, which can lead to errors if variable are rename in the future.
 
 ## Thanks
 

--- a/Sources/ValidationsKit/ValidationError.swift
+++ b/Sources/ValidationsKit/ValidationError.swift
@@ -52,3 +52,22 @@ public struct UndefinedValidationError: Error, CustomStringConvertible {
     }
 
 }
+
+/// Error thrown when some validation failed but user defined it's own error message
+public struct CustomValidationError: Error, CustomStringConvertible {
+
+    /// Message provided by the user
+    let message: String
+
+    /// Readable description of `CustomValidationError`
+    public var description: String {
+        return message
+    }
+
+    /// Create a new `CustomValidationError`
+    /// - parameter message: Error message provided by the user.
+    public init(_ message: String) {
+        self.message = message
+    }
+
+}

--- a/Sources/ValidationsKit/Validator.swift
+++ b/Sources/ValidationsKit/Validator.swift
@@ -13,24 +13,34 @@ public struct Validator<T> {
     /// Readable name explaining what this `Validator` does. Must be suitable for placing after `is` _and_ `is not`.
     public var readable: String
 
+    /// Error message provided by the user to throw in case of validation failure
+    private let message: ((T) -> String)?
+
     /// Validates the supplied `ValidationData`, throwing an error if it is not valid.
     /// - parameter data: `ValidationData` to validate.
     /// - throws: `ValidationError` if the data is not valid, or another error if something fails.
-    private let closure: (T) throws -> Void
+    private let validator: (T) throws -> Void
 
     /// Create a new `Validation`.
     /// - parameter readable: Readable name, suitable for placing after `is` _and_ `is not`.
+    /// - parameter message: Error message provided by the user to throw in case of validation failure
     /// - parameter validate: Validates the supplied `ValidationData`, throwing and error if it is not valid.
-    public init(_ readable: String, _ closure: @escaping (T) throws -> Void) {
+    public init(_ readable: String, message: ((T) -> String)? = nil, _ validator: @escaping (T) throws -> Void) {
         self.readable = readable
-        self.closure = closure
+        self.message = message
+        self.validator = validator
     }
 
     /// Validates the supplied `ValidationData`, throwing an error if it is not valid.
     /// - parameter data: `ValidationData` to validate.
     /// - throws: `ValidationError` if the data is not valid, or another error if something fails.
     public func validate(_ data: T) throws {
-        try closure(data)
+        do {
+            try validator(data)
+        } catch {
+            guard let message = message else { throw error }
+            throw CustomValidationError(message(data))
+        }
     }
 
 }


### PR DESCRIPTION
As suggested by this [issue](https://github.com/amoriarty/ValidationsKit/issues/6), this pull request implement the possibility to defined custom error messages as follow:

```swift
validations.add(\.username, at: ["username"], !.empty) { _ in
    NSLocalizedString("Username can't be empty", comment: "Error message when user try to sign in with empty user")
}
```
```swift
validations.add(\.number, at: ["number"], .range(0 ..< 10) { number in
    "\(number) is not between 0 and 10, try again!"
}
```