### PR TITLE
[features] Custom validation with model

### DIFF
--- a/Sources/ValidationsKit/Validations.swift
+++ b/Sources/ValidationsKit/Validations.swift
@@ -51,7 +51,7 @@ public struct Validations<Model> where Model: Validatable {
     ///     - keyPath: `KeyPath` associated with validation.
     ///     - path: Readable path. Will be displayed when showing errors.
     ///     - readable: Readable message. Will be displayed when showing errors.
-    ///     - validation: Validation closure with full model.
+    ///     - validator: Validation closure with full model.
     ///     - message: Error message provided by the user and throw in case of validation error.
     public mutating func add<T>(_ keyPath: KeyPath<Model, T>,
                                 at path: [String],
@@ -115,6 +115,26 @@ extension Validations where Model: Reflectable {
             validator: validator,
             message: message
         )
+    }
+
+    /// Adds a custom validation at the supplied key path and readable,
+    /// with validator taking whole model instead of just the supplied key path.
+    ///
+    /// - parameters:
+    ///     - keyPath: `KeyPath` associated with validation.
+    ///     - readable: Readable message. Will be displayed when showing errors.
+    ///     - validator: Validation closure with full model.
+    ///     - message: Error message provided by the user and throw in case of validation error.
+    public mutating func add<T>(_ keyPath: KeyPath<Model, T>,
+                                _ readable: String = "",
+                                withModel validator: @escaping (Model) throws -> Void,
+                                message: ((T) -> String)? = nil) throws {
+        try add(
+            keyPath,
+            at: Model.reflectProperty(forKey: keyPath)?.path ?? [],
+            readable,
+            withModel: validator,
+            message: message)
     }
 
 }

--- a/Sources/ValidationsKit/Validations.swift
+++ b/Sources/ValidationsKit/Validations.swift
@@ -56,6 +56,54 @@ public struct Validations<Model> where Model: Validatable {
         )
     }
 
+}
+
+// MARK: - Reflectable
+
+extension Validations where Model: Reflectable {
+
+    /// Adds a new `Validation` at the supplied key path. Readable path will be reflected.
+    ///
+    ///     try validations.add(\.name, .count(5...) && .alphanumeric)
+    ///
+    /// - parameters:
+    ///     - keyPath: `KeyPath` to validatable property.
+    ///     - validator: `Validation` to run on this property.
+    public mutating func add<T>(_ keyPath: KeyPath<Model, T>,
+                                _ validator: Validator<T>,
+                                _ message: ((T) -> String)? = nil) throws {
+        try add(keyPath, at: Model.reflectProperty(forKey: keyPath)?.path ?? [], validator, message: message)
+    }
+
+    /// Adds a new custom `Validation` at the supplied key path. Readable path will be reflected.
+    ///
+    ///     try validations.add(\.name, "is vapor") { name in
+    ///         guard name == "vapor" else { throw }
+    ///     }
+    ///
+    /// - parameters:
+    ///     - keyPath: `KeyPath` to validatable property.
+    ///     - readable: Readable string describing this validation.
+    ///     - validator: Closure accepting the `KeyPath`'s value. Throw a `ValidationError` here if the data is invalid.
+    public mutating func add<T>(_ keyPath: KeyPath<Model, T>,
+                                _ readable: String = "",
+                                validator: @escaping (T) throws -> Void,
+                                message: ((T) -> String)? = nil) throws {
+        try add(
+            keyPath,
+            at: Model.reflectProperty(forKey: keyPath)?.path ?? [],
+            readable,
+            validator: validator,
+            message: message
+        )
+    }
+
+}
+
+// MARK: - Run
+
+extension Validations {
+
     /// Runs the `Validation`s on an instance of `Model`.
     /// - parameter model: Model on which validation must be done.
     func run(on model: Model) throws {
@@ -82,46 +130,6 @@ public struct Validations<Model> where Model: Validatable {
 
             try validation.validate(model)
         }
-    }
-
-}
-
-extension Validations where Model: Reflectable {
-
-    /// Adds a new `Validation` at the supplied key path. Readable path will be reflected.
-    ///
-    ///     try validations.add(\.name, .count(5...) && .alphanumeric)
-    ///
-    /// - parameters:
-    ///     - keyPath: `KeyPath` to validatable property.
-    ///     - validator: `Validation` to run on this property.
-    public mutating func add<T>(_ keyPath: KeyPath<Model, T>,
-                                _ validator: Validator<T>,
-                                message: ((T) -> String)? = nil) throws {
-        try add(keyPath, at: Model.reflectProperty(forKey: keyPath)?.path ?? [], validator, message: message)
-    }
-
-    /// Adds a new custom `Validation` at the supplied key path. Readable path will be reflected.
-    ///
-    ///     try validations.add(\.name, "is vapor") { name in
-    ///         guard name == "vapor" else { throw }
-    ///     }
-    ///
-    /// - parameters:
-    ///     - keyPath: `KeyPath` to validatable property.
-    ///     - readable: Readable string describing this validation.
-    ///     - validator: Closure accepting the `KeyPath`'s value. Throw a `ValidationError` here if the data is invalid.
-    public mutating func add<T>(_ keyPath: KeyPath<Model, T>,
-                                _ readable: String,
-                                _ validator: @escaping (T) throws -> Void,
-                                message: ((T) -> String)? = nil) throws {
-        try add(
-            keyPath,
-            at: Model.reflectProperty(forKey: keyPath)?.path ?? [],
-            readable,
-            validator: validator,
-            message: message
-        )
     }
 
 }

--- a/Tests/ValidationsKitTests/ReflectableTests.swift
+++ b/Tests/ValidationsKitTests/ReflectableTests.swift
@@ -14,32 +14,40 @@ final class ReflectableTests: XCTestCase {
     struct User: Codable, Reflectable, Validatable {
         let username: String
         let password: String
+        let twitter: String
         let message: String
 
         static func validations() throws -> Validations<ReflectableTests.User> {
             var validations = Validations(User.self)
             try validations.add(\.username, !.empty)
             try validations.add(\.password, .count(8...))
+
+            try validations.add(\.twitter, validator: { twitter in
+                guard !twitter.hasPrefix("@") else { return }
+                throw BasicValidationError("")
+            }, message: { _ in "Twitter username should start with '@'" })
+
             try validations.add(\.message, .count(8 ..< 12)) { message in
                 "Your message: '\(message)' isn't nil or between 8 and 12 characters"
             }
+
             return validations
         }
     }
 
     func testReflectable() {
-        let user = User(username: "username", password: "password1234", message: "somemessage")
+        let user = User(username: "username", password: "password1234", twitter: "@user", message: "somemessage")
         XCTAssertNoThrow(try user.validate())
     }
 
     func testReflectableWithError() {
-        let username = User(username: "", password: "password1234", message: "somemessage")
+        let username = User(username: "", password: "password1234", twitter: "@user", message: "somemessage")
 
         XCTAssertThrowsError(try username.validate()) { error in
             XCTAssertEqual("\(error)", "'username' is empty")
         }
 
-        let password = User(username: "username", password: "pwd", message: "somemessage")
+        let password = User(username: "username", password: "pwd", twitter: "@user", message: "somemessage")
 
         XCTAssertThrowsError(try password.validate()) { error in
             XCTAssertEqual("\(error)", "'password' is less than required minimum of 8 characters")
@@ -47,10 +55,18 @@ final class ReflectableTests: XCTestCase {
     }
 
     func testReflectableWithCustomError() {
-        let user = User(username: "username", password: "password1234", message: "")
+        let user = User(username: "username", password: "password1234", twitter: "@user", message: "")
 
         XCTAssertThrowsError(try user.validate()) { error in
             XCTAssertEqual("\(error)", "Your message: '' isn't nil or between 8 and 12 characters")
+        }
+    }
+
+    func testReflectableWithCustomValidator() {
+        let user = User(username: "username", password: "password1234", twitter: "user", message: "somemessage")
+
+        XCTAssertThrowsError(try user.validate()) { error in
+            XCTAssertEqual("\(error)", "Twitter username should start with '@'")
         }
     }
 

--- a/Tests/ValidationsKitTests/ReflectableTests.swift
+++ b/Tests/ValidationsKitTests/ReflectableTests.swift
@@ -11,6 +11,13 @@ import XCTest
 
 final class ReflectableTests: XCTestCase {
 
+    static let allTests = [
+        ("testReflectable", testReflectable),
+        ("testReflectableWithError", testReflectableWithError),
+        ("testReflectableWithCustomError", testReflectableWithCustomError),
+        ("testReflectableWithCustomValidator", testReflectableWithCustomValidator)
+    ]
+
     struct User: Codable, Reflectable, Validatable {
         let username: String
         let password: String

--- a/Tests/ValidationsKitTests/ValidationFromModelTests.swift
+++ b/Tests/ValidationsKitTests/ValidationFromModelTests.swift
@@ -1,0 +1,45 @@
+//
+//  ValidationFromModelTests.swift
+//  ValidationsKit
+//
+//  Created by Alexandre Legent on 30/12/2019.
+//
+
+import Foundation
+import XCTest
+@testable import ValidationsKit
+
+final class ValidationFromModelTests: XCTestCase {
+
+    static let allTests = [
+        ("testValidationFromModel", testValidationFromModel)
+    ]
+
+    struct Contact: Codable, Reflectable, Validatable {
+        let mail: String
+
+        var isValid: Bool {
+            !mail.isEmpty
+        }
+
+        static func validations() throws -> Validations<Contact> {
+            var validations = Validations(Contact.self)
+
+            validations.add(\.mail, at: ["mail"], withModel: { contact in
+                guard !contact.isValid else { return }
+                throw BasicValidationError("shouldn't be empty")
+            })
+
+            return validations
+        }
+    }
+
+    func testValidationFromModel() {
+        XCTAssertNoThrow(try Contact(mail: "user@mail.com").validate())
+        XCTAssertThrowsError(try Contact(mail: "").validate()) { error in
+            XCTAssertEqual("\(error)", "'mail' shouldn't be empty")
+        }
+
+    }
+
+}

--- a/Tests/ValidationsKitTests/ValidationFromModelTests.swift
+++ b/Tests/ValidationsKitTests/ValidationFromModelTests.swift
@@ -17,8 +17,9 @@ final class ValidationFromModelTests: XCTestCase {
 
     struct Contact: Codable, Reflectable, Validatable {
         let mail: String
+        let message: String
 
-        var isValid: Bool {
+        var isValidMail: Bool {
             !mail.isEmpty
         }
 
@@ -26,20 +27,28 @@ final class ValidationFromModelTests: XCTestCase {
             var validations = Validations(Contact.self)
 
             validations.add(\.mail, at: ["mail"], withModel: { contact in
-                guard !contact.isValid else { return }
+                guard !contact.isValidMail else { return }
                 throw BasicValidationError("shouldn't be empty")
             })
+
+            try validations.add(\.message, withModel: { contact in
+                guard contact.message.isEmpty else { return }
+                throw BasicValidationError("")
+            }, message: { "message '\($0)' shouldn't be empty" })
 
             return validations
         }
     }
 
     func testValidationFromModel() {
-        XCTAssertNoThrow(try Contact(mail: "user@mail.com").validate())
-        XCTAssertThrowsError(try Contact(mail: "").validate()) { error in
+        XCTAssertNoThrow(try Contact(mail: "user@mail.com", message: "some message").validate())
+        XCTAssertThrowsError(try Contact(mail: "", message: "some message").validate()) { error in
             XCTAssertEqual("\(error)", "'mail' shouldn't be empty")
         }
 
+        XCTAssertThrowsError(try Contact(mail: "user@mail.com", message: "").validate()) { error in
+            XCTAssertEqual("\(error)", "message '' shouldn't be empty")
+        }
     }
 
 }

--- a/Tests/ValidationsKitTests/ValidationsKitTests.swift
+++ b/Tests/ValidationsKitTests/ValidationsKitTests.swift
@@ -1,58 +1,62 @@
 import XCTest
 @testable import ValidationsKit
 
-struct UserModel: Validatable {
-    var mail: String
-    var phone: String
-    var picture: String?
-    var ascii: String
-    var alphanumeric: String
-    var password: String
-    var delivery: String
-    var github: String
-    var twitter: String?
-    var customMessage: String
-    var noValidator: String?
-
-    static func validations() throws -> Validations<UserModel> {
-        var validations = Validations(UserModel.self)
-        validations.add(\.mail, at: ["mail"], !.empty && .mail)
-        validations.add(\.phone, at: ["phone"], .phone)
-        validations.add(\.picture, at: ["picture"], .nil || .url)
-        validations.add(\.ascii, at: ["ascii"], .ascii)
-        validations.add(\.alphanumeric, at: ["alphanumeric"], .alphanumeric)
-        validations.add(\.password, at: ["password"], .alphanumeric && .count(8...12))
-        validations.add(\.delivery, at: ["delivery"], .in("short", "long"))
-        validations.add(\.github, at: ["github"], validator: { link in
-            guard !link.contains("https://github.com") else { return }
-            throw BasicValidationError("isn't a valid GitHub link")
-        })
-        validations.add(\.twitter, at: ["twitter"], validator: { twitter in
-            guard let twitter = twitter else { return }
-            guard twitter.first != "@" else { return }
-            throw BasicValidationError("isn't a valid Twitter username")
-        })
-
-        validations.add(\.customMessage, at: ["customMessage"], !.empty) { _ in
-            return "this custom error message should appear instead of the auto generated one"
-        }
-
-        return validations
-    }
-
-}
-
 final class ValidationsKitTests: XCTestCase {
-    private var user: UserModel!
+    private var user: User!
 
     static let allTests = [
         ("testValidate", testValidate),
         ("testSingleFieldValidate", testSingleFieldValidate),
-        ("testCustomValidation", testCustomValidation)
+        ("testMultipleFieldsValidate", testMultipleFieldsValidate),
+        ("testCustomValidation", testCustomValidation),
+        ("testCustomErrorMessage", testCustomErrorMessage)
     ]
 
+    struct User: Validatable {
+        var mail: String
+        var phone: String
+        var picture: String?
+        var ascii: String
+        var alphanumeric: String
+        var password: String
+        var delivery: String
+        var github: String
+        var twitter: String?
+        var customMessage: String
+        var noValidator: String?
+
+        static func validations() throws -> Validations<User> {
+            var validations = Validations(User.self)
+            validations.add(\.mail, at: ["mail"], !.empty && .mail)
+            validations.add(\.phone, at: ["phone"], .phone)
+            validations.add(\.picture, at: ["picture"], .nil || .url)
+            validations.add(\.ascii, at: ["ascii"], .ascii)
+            validations.add(\.alphanumeric, at: ["alphanumeric"], .alphanumeric)
+            validations.add(\.password, at: ["password"], .alphanumeric && .count(8...12))
+            validations.add(\.delivery, at: ["delivery"], .in("short", "long"))
+
+            validations.add(\.github, at: ["github"], validator: { link in
+                guard !link.contains("https://github.com") else { return }
+                throw BasicValidationError("isn't a valid GitHub link")
+            })
+
+            validations.add(\.twitter, at: ["twitter"], validator: { twitter in
+                guard let twitter = twitter else { return }
+                guard twitter.first != "@" else { return }
+                throw BasicValidationError("isn't a valid Twitter username")
+            })
+
+            validations.add(\.customMessage, at: ["customMessage"], !.empty) { _ in
+                return "this custom error message should appear instead of the auto generated one"
+            }
+
+            return validations
+        }
+
+    }
+
     override func setUp() {
-        user = UserModel(
+        user = User(
             mail: "valid@example.com",
             phone: "+33642424242",
             picture: nil,
@@ -73,20 +77,20 @@ final class ValidationsKitTests: XCTestCase {
 
     func testSingleFieldValidate() {
         user.phone = ""
-        XCTAssertNoThrow(try user.validate(at: \UserModel.mail))
-        XCTAssertThrowsError(try user.validate(at: \UserModel.phone)) { error in
+        XCTAssertNoThrow(try user.validate(at: \User.mail))
+        XCTAssertThrowsError(try user.validate(at: \User.phone)) { error in
             XCTAssertEqual("\(error)", "'phone' isn't a valid phone number")
         }
 
-        XCTAssertThrowsError(try user.validate(at: \UserModel.noValidator)) { error in
+        XCTAssertThrowsError(try user.validate(at: \User.noValidator)) { error in
             XCTAssertNotNil(error as? UndefinedValidationError)
         }
     }
 
     func testMultipleFieldsValidate() {
         user.phone = ""
-        XCTAssertNoThrow(try user.validate(at: \UserModel.mail, \UserModel.twitter))
-        XCTAssertThrowsError(try user.validate(at: \UserModel.mail, \UserModel.phone)) { error in
+        XCTAssertNoThrow(try user.validate(at: \User.mail, \User.twitter))
+        XCTAssertThrowsError(try user.validate(at: \User.mail, \User.phone)) { error in
             XCTAssertEqual("\(error)", "'phone' isn't a valid phone number")
         }
     }
@@ -100,7 +104,7 @@ final class ValidationsKitTests: XCTestCase {
 
     func testCustomErrorMessage() {
         user.customMessage = ""
-        XCTAssertThrowsError(try user.validate(at: \UserModel.customMessage)) { error in
+        XCTAssertThrowsError(try user.validate(at: \User.customMessage)) { error in
             XCTAssertNotNil(error as? CustomValidationError)
             XCTAssertEqual("\(error)", "this custom error message should appear instead of the auto generated one")
         }

--- a/Tests/ValidationsKitTests/XCTestManifests.swift
+++ b/Tests/ValidationsKitTests/XCTestManifests.swift
@@ -4,7 +4,9 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(ValidationsKitTests.allTests),
-        testCase(ValidatorsTests.allTests)
+        testCase(ValidatorsTests.allTests),
+        testCase(ReflectableTests.allTests),
+        testCase(ValidationFromModelTests.allTests)
     ]
 }
 #endif


### PR DESCRIPTION
This PR allow user to define custom validations by taking the entire object as parameter instead of the field tested itself.
This allow to access other attributes from the object when validating a single field:
```swift
struct User: Decodable, Reflectable {
    // A custom date formatter to validate the user birthday
    let formatter = DateFormatter()

    // Field set by the end user
    let birthday: String
}

extension User: Validatable {

    static func validations() throws -> Validations<User> {
        var validations = Validations(User.self)

        // We now can define a validation on the entire user, 
        // allowing us to access other field (here formatter)
        try validations.add(\.message, withModel: { user in
            guard user.formatter.date(from: user.birthday) == nil else { return }
            throw BasicValidationError("is not a valid date.")
        })

        return validations
    }

}
```